### PR TITLE
Vcurents

### DIFF
--- a/farol_bringup/config/dev_configs/permanent_ros.yaml
+++ b/farol_bringup/config/dev_configs/permanent_ros.yaml
@@ -104,6 +104,10 @@ nav/filter:
         publishers:
             state: "/#vehicle#/nav/filter/state"
             currents: "/#vehicle#/nav/filter/currents"
+            state_sensors: "/#vehicle#/nav/filter/State_sensors"
+            vc_meas_velocity: "/#vehicle#/nav/filter/vc_meas_velocity"
+            vc_meas_position: "/#vehicle#/nav/filter/vc_meas_position"
+
     topics_dr:
        velocity: "/#vehicle#/measurement/velocity"
        orientation: "/#vehicle#/measurement/orientation"
@@ -113,6 +117,11 @@ nav/filter:
        dead_reckoning_console: "/#vehicle#/State_dr"
     services_dr:
        reset_filter_dr: "/#vehicle#/nav/reset_filter_dr"
+    services:
+       set_vcurrent_velocity: "/#vehicle#/nav/set_vcurrent_velocity"
+       reset_vcurrent: "/#vehicle#/nav/reset_vcurrent"
+
+
 
 nav/gnss2utm:
     node_frequency: 10

--- a/farol_nav/sensor_fusion/CMakeLists.txt
+++ b/farol_nav/sensor_fusion/CMakeLists.txt
@@ -15,6 +15,16 @@ find_package(catkin REQUIRED
  cmake_modules
 )
 
+add_service_files(
+  FILES
+  SetVCurrentVelocity.srv
+)
+
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
+
 catkin_package(
  CATKIN_DEPENDS
  tf2_geometry_msgs

--- a/farol_nav/sensor_fusion/include/ros/FiltersNode.h
+++ b/farol_nav/sensor_fusion/include/ros/FiltersNode.h
@@ -104,7 +104,9 @@ private:
   ros::Publisher state_pub_;                   ///< State publisher
   ros::Publisher currents_pub_;                ///< Currents publisher
   ros::Publisher state_sensors_pub_;           ///< "State" with only information from the most recent sensors publisher
-	
+	ros::Publisher vc_meas_velocity_pub_;
+  ros::Publisher vc_meas_position_pub_;
+
   // @.@ Services
   ros::ServiceServer set_vcurrent_velocity_srv_;
   ros::ServiceServer reset_vcurrent_srv_;
@@ -112,7 +114,8 @@ private:
   // @.@ Timer
 	ros::Timer timer_;                           ///< Principal timer iterator
   ros::Timer list_cleaner_timer_;              ///< Clear measurement list 
-	tf2_ros::Buffer tfBuffer_;                   ///< Tf Buffer
+  ros::Timer serviceslist_cleaner_timer_;      ///< ???
+  tf2_ros::Buffer tfBuffer_;                   ///< Tf Buffer
   tf2_ros::TransformListener *tfListener_;     ///< tf listener
 
   // @.@ Frames tfs
@@ -308,7 +311,8 @@ private:
 
   /* -------------------------------------------------------------------------*/
   /**
-   * @brief Function to handle set_vcurrent_velocity service. Sets some relevant class variable 
+   * @brief Function to handle set_vcurrent_velocity service. Sets the virtual currents
+   *        velocity to the value requested by the service
    *
    * @param req service Request
    * @param res service Response
@@ -318,7 +322,8 @@ private:
 
   /* -------------------------------------------------------------------------*/
   /**
-   * @brief Function to handle reset_vcurrent service. Sets to 0 some relevant class variable 
+   * @brief Function to handle reset_vcurrent service. Sets to the default values all
+   *        variables used for simulating the virtual currents 
    *
    * @param req service Request
    * @param res service Response
@@ -328,13 +333,25 @@ private:
 
   /* -------------------------------------------------------------------------*/
   /**
-   * @brief This function simulates the effect of currents in the measurements from the sensors. It takes in a dsor_msgs Measurement message and changes it or not depending on the effect of the virtual currents active 
+   * @brief This function simulates the effect of currents in the measurements from the sensors.
+   *        It takes in a dsor_msgs Measurement message and changes it or not depending on the 
+   *        effect of the set virtual current velocity
    *
    * @param msg the measurement to be changed
    */
   /* -------------------------------------------------------------------------*/
-  void  virtualCurrents(const dsor_msgs::Measurement &msg);
+  void virtualCurrents(const dsor_msgs::Measurement &msg);
 
+  /* -------------------------------------------------------------------------*/
+  /**
+   * @brief This function publishes a State message for the console with the last measurements
+   *        from the sensors. Its not filtered so its quite noisy, just used for reference on 
+   *        the real position of the vehicle when the filter is being changed with virtual currents
+   *
+   * @param msg the most recent measurement
+   */
+  /* -------------------------------------------------------------------------*/
+  void sensorsState(const dsor_msgs::Measurement &msg);
 
 };
 #endif //CATKIN_WS_FILTERSNODE_H

--- a/farol_nav/sensor_fusion/include/ros/FiltersNode.h
+++ b/farol_nav/sensor_fusion/include/ros/FiltersNode.h
@@ -155,12 +155,12 @@ private:
   double vc_last_offx_{0.0};
   double vc_last_offy_{0.0};
 
-  // @.@ Variables for "state" obtained from sensors [x,y,teta]
+  // @.@ Variables for "state" obtained from sensors [x,y,yaw]
   double sensor_x_{0};
   double sensor_y_{0};
   double xy_time_{-1};
-  double sensor_teta_{0};
-  double teta_time_{-1};
+  double sensor_yaw_{0};
+  double yaw_time_{-1};
   double sensor_vx_{0};
   double sensor_vy_{0};
   double v_time_{-1};

--- a/farol_nav/sensor_fusion/package.xml
+++ b/farol_nav/sensor_fusion/package.xml
@@ -16,6 +16,9 @@
  <buildtool_depend>catkin</buildtool_depend>
  <build_depend>cmake_modules</build_depend>
 
+ <build_depend>message_generation</build_depend>
+ <exec_depend>message_runtime</exec_depend>
+
  <depend>std_msgs</depend>
  <depend>tf2_geometry_msgs</depend>
  <depend>roscpp</depend>

--- a/farol_nav/sensor_fusion/src/ros/FiltersNode.cpp
+++ b/farol_nav/sensor_fusion/src/ros/FiltersNode.cpp
@@ -627,9 +627,9 @@ void FiltersNode::sensorSplit(const FilterGimmicks::measurement &m_in,
   }
   // Save most recent orientation measurement
   else if( t_frame == std::string("ahrs") ){ 
-    if (msg.header.stamp.toSec() > teta_time_){
-      sensor_teta_ = msg.value[2];
-      teta_time_ = msg.header.stamp.toSec();
+    if (msg.header.stamp.toSec() > yaw_time_){
+      sensor_yaw_ = msg.value[2];
+      yaw_time_ = msg.header.stamp.toSec();
     }
   }
   // Publish state for the console /#vehicle#/nav/filter/State_sensors
@@ -638,10 +638,10 @@ void FiltersNode::sensorSplit(const FilterGimmicks::measurement &m_in,
     state_sensors_.header.stamp = ros::Time::now();
     state_sensors_.X = sensor_y_;
     state_sensors_.Y = sensor_x_;
-    state_sensors_.Yaw = sensor_teta_*180/3.14159265359;
+    state_sensors_.Yaw = sensor_yaw_*180/M_PI;
     state_sensors_.Vx = sensor_vx_;
     state_sensors_.Vy = sensor_vy_;
-    state_sensors_.u = sensor_vx_ / cos(sensor_teta_);
+    state_sensors_.u = sensor_vx_ / cos(sensor_yaw_);
     state_sensors_pub_.publish(state_sensors_);
   }
  }

--- a/farol_nav/sensor_fusion/srv/SetVCurrentVelocity.srv
+++ b/farol_nav/sensor_fusion/srv/SetVCurrentVelocity.srv
@@ -1,0 +1,5 @@
+float64 velocity_x
+float64 velocity_y
+---
+bool success
+string message


### PR DESCRIPTION
Added the Simulation of virtual currents:
  -> Works by changing the measurement msgs before entering the filter
  -> Changes the output of the filter to what it would be if there were sea currents
  -> Publishes the real state of the vehicle to  "/#vehicle#/nav/filter/State_sensors"
  -> Interfaced through ROS services:
      - service to define a virtual current velocity: "/#vehicle#/nav/set_vcurrent_velocity"
      - service to stop a virtual current velocity: "/#vehicle#/nav/reset_vcurrent"
